### PR TITLE
FEATURE: Add TypeScript definitions

### DIFF
--- a/lib/sb-editable.d.ts
+++ b/lib/sb-editable.d.ts
@@ -1,17 +1,17 @@
 import React from 'react'
 export interface SbEditableContent {
-  _uid: string
-  _editable?: string
-  component: string
-  [index: string]: any
+    _uid: string
+    _editable?: string
+    component: string
+    [index: string]: any
 }
 interface SbEditableProps {
-  content: SbEditableContent
+    content: SbEditableContent
 }
 declare class SbEditable extends React.Component<SbEditableProps, {}> {
-  constructor(props: SbEditableProps)
-  componentDidMount(): void
-  addClass(el: HTMLElement, className: string): void
-  render(): React.ReactNode
+    constructor(props: SbEditableProps)
+    componentDidMount(): void
+    addClass(el: HTMLElement, className: string): void
+    render(): React.ReactNode
 }
 export default SbEditable

--- a/lib/sb-editable.d.ts
+++ b/lib/sb-editable.d.ts
@@ -1,13 +1,17 @@
-import React from 'react';
+import React from 'react'
+export interface SbEditableContent {
+  _uid: string
+  _editable?: string
+  component: string
+  [index: string]: any
+}
 interface SbEditableProps {
-    content: {
-        _editable?: string;
-    };
+  content: SbEditableContent
 }
 declare class SbEditable extends React.Component<SbEditableProps, {}> {
-    constructor(props: SbEditableProps);
-    componentDidMount(): void;
-    addClass(el: HTMLElement, className: string): void;
-    render(): React.ReactNode;
+  constructor(props: SbEditableProps)
+  componentDidMount(): void
+  addClass(el: HTMLElement, className: string): void
+  render(): React.ReactNode
 }
-export default SbEditable;
+export default SbEditable

--- a/lib/sb-editable.d.ts
+++ b/lib/sb-editable.d.ts
@@ -1,0 +1,13 @@
+import React from 'react';
+interface SbEditableProps {
+    content: {
+        _editable?: string;
+    };
+}
+declare class SbEditable extends React.Component<SbEditableProps, {}> {
+    constructor(props: SbEditableProps);
+    componentDidMount(): void;
+    addClass(el: HTMLElement, className: string): void;
+    render(): React.ReactNode;
+}
+export default SbEditable;

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "author": "Alexander Feiglstorfer",
   "license": "MIT",
   "main": "./lib/sb-editable.js",
+  "types": "./lib/sb-editable.d.ts",
   "scripts": {
     "build": "babel -d lib/ src/  && date",
     "build:watch": "watch 'npm run build' ./src"


### PR DESCRIPTION
I am using this at the moment and there are no typing errors popping up.

I have extracted `SbEditableContent` from `SbEditable` because there was an instance when I wanted to use a StoryBlok component's content outside of a `SbEditable` and it was nicer to be able to do the following:

```typescript
import SbEditable, { SbEditableContent } from 'storyblok-react'

export interface HeroContent extends SbEditableContent {
  headline: string
  subtitle: string
  image: string
  aspect_ratio: string
  text_colour: { color: string }
  text_shadow: boolean
}

interface HeroProps {
  content: HeroContent
}

interface HeroState {
  // ...
}

export default class Hero extends React.PureComponent<HeroProps, HeroState> {
  // ...
}
```