### PR TITLE
Misc fixes

### DIFF
--- a/lib/sb-editable.js
+++ b/lib/sb-editable.js
@@ -34,12 +34,12 @@ var SbEditable = function (_React$Component) {
   _createClass(SbEditable, [{
     key: 'componentDidMount',
     value: function componentDidMount() {
-      if (typeof this.props.content._editable === 'undefined' || window && window.location === window.parent.location) {
+      if (typeof this.props.content._editable === 'undefined' || window.location === window.parent.location) {
         return;
       }
 
       var el = _reactDom2.default.findDOMNode(this);
-      var options = JSON.parse(this.props.content._editable.replace('<!--#storyblok#', '').replace('-->', ''));
+      var options = JSON.parse(this.props.content._editable.replace(/^<!--#storyblok#/, '').replace(/-->$/, ''));
 
       if (el instanceof Object && typeof el.setAttribute === 'function') {
         el.setAttribute('data-blok-c', JSON.stringify(options));
@@ -47,7 +47,7 @@ var SbEditable = function (_React$Component) {
 
         this.addClass(el, 'storyblok__outline');
       } else {
-        console.warn('I seams that you are using a text dom element inside the SbEditable wrapper. Please wrap it with a HTML dom element.');
+        throw new TypeError('It seems that you are using a DOM text node inside the SbEditable wrapper. Please wrap it with an HTML DOM element.');
       }
     }
   }, {

--- a/src/sb-editable.jsx
+++ b/src/sb-editable.jsx
@@ -21,7 +21,7 @@ class SbEditable extends React.Component {
 
       this.addClass(el, 'storyblok__outline')
     } else {
-      console.warn('I seams that you are using a text dom element inside the SbEditable wrapper. Please wrap it with a HTML dom element.')
+      console.warn('It seems that you are using a DOM text node inside the SbEditable wrapper. Please wrap it with an HTML DOM element.')
     }
   }
 

--- a/src/sb-editable.jsx
+++ b/src/sb-editable.jsx
@@ -21,7 +21,7 @@ class SbEditable extends React.Component {
 
       this.addClass(el, 'storyblok__outline')
     } else {
-      console.warn('It seems that you are using a DOM text node inside the SbEditable wrapper. Please wrap it with an HTML DOM element.')
+      throw new TypeError('It seems that you are using a DOM text node inside the SbEditable wrapper. Please wrap it with an HTML DOM element.')
     }
   }
 

--- a/src/sb-editable.jsx
+++ b/src/sb-editable.jsx
@@ -8,7 +8,7 @@ class SbEditable extends React.Component {
 
   componentDidMount() {
     if (typeof this.props.content._editable === 'undefined' ||
-        (window && window.location === window.parent.location)) {
+        window.location === window.parent.location) {
       return
     }
 

--- a/src/sb-editable.jsx
+++ b/src/sb-editable.jsx
@@ -13,7 +13,7 @@ class SbEditable extends React.Component {
     }
 
     var el = ReactDOM.findDOMNode(this)
-    var options = JSON.parse(this.props.content._editable.replace('<!--#storyblok#', '').replace('-->', ''))
+    var options = JSON.parse(this.props.content._editable.replace(/^<!--#storyblok#/, '').replace(/-->$/, ''))
 
     if (el instanceof Object && typeof el.setAttribute === 'function') {
       el.setAttribute('data-blok-c', JSON.stringify(options))


### PR DESCRIPTION
- Remove redundant `window` check (`componentDidMount` is only called on the client side)
- More reliable JSON parsing (only remove comments from the start/end, respectively)
- Fix typos and improve text flow in error message
- Throw `TypeError` instead of `console.warn()`ing to show stack trace (and since this is an error anyway, not just a warning) - fixes #5