### PR TITLE
fix: don't bundle @storyblok/js

### DIFF
--- a/lib/vite.config.ts
+++ b/lib/vite.config.ts
@@ -13,9 +13,12 @@ export default defineConfig(() => {
           format === "es" ? `${libName}.mjs` : `${libName}.js`,
       },
       rollupOptions: {
-        external: ["react", "axios"],
+        external: ["react", "axios", "@storyblok/js" ],
         output: {
-          globals: { react: "React" },
+          globals: { 
+            react: "React", 
+            "@storyblok/js": "storyblokJs" 
+          },
         },
       },
     },


### PR DESCRIPTION
Bundling Libraries and setting them as dependencies means that you end
up with twice the code but none of the convenience of a package manager.

see also: https://github.com/storyblok/storyblok-js/pull/82