### PR TITLE
fix: StoryblokComponent forwardRef

### DIFF
--- a/lib/components/storyblok-component.tsx
+++ b/lib/components/storyblok-component.tsx
@@ -1,28 +1,33 @@
-import React from "react";
-import type { SbBlokData } from "../types";
+import React, { forwardRef } from "react";
 import { getComponent } from "../index";
+import type { SbBlokData } from "../types";
 
 interface StoryblokComponentProps {
   blok: SbBlokData;
   [key: string]: unknown;
 }
 
-const StoryblokComponent = ({
-  blok,
-  ...restProps
-}: StoryblokComponentProps) => {
-  if (!blok) {
-    console.error("Please provide a 'blok' property to the StoryblokComponent");
-    return <div>Please provide a blok property to the StoryblokComponent</div>;
+const StoryblokComponent = forwardRef<HTMLElement, StoryblokComponentProps>(
+  ({ blok, ...restProps }, ref) => {
+    if (!blok) {
+      console.error(
+        "Please provide a 'blok' property to the StoryblokComponent"
+      );
+      return (
+        <div>Please provide a blok property to the StoryblokComponent</div>
+      );
+    }
+
+    const Component = getComponent(blok.component);
+
+    if (Component) {
+      return <Component ref={ref} blok={blok} {...restProps} />;
+    }
+
+    return <div></div>;
   }
+);
 
-  const Component = getComponent(blok.component);
-
-  if (Component) {
-    return <Component blok={blok} {...restProps} />;
-  }
-
-  return <div></div>;
-};
+StoryblokComponent.displayName = "StoryblokComponent";
 
 export default StoryblokComponent;

--- a/lib/cypress/component/index.spec.jsx
+++ b/lib/cypress/component/index.spec.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import Test from "../../testing-components/Test";
 import TestUseStoryblok from "../../testing-components/TestUseStoryblok";
 import { mount } from "@cypress/react";
+import RefChecker from "@storyblok/react-playground/components/ref-checker";
 import Teaser from "@storyblok/react-playground/components/teaser";
 import Grid from "@storyblok/react-playground/components/grid";
 import Feature from "@storyblok/react-playground/components/feature";
@@ -108,6 +109,28 @@ describe("@storyblok/react", () => {
         "be.calledWithMatch",
         "Component teaser doesn't exist."
       );
+    });
+
+    it("Should pass ref to a 'real' component", () => {
+      const blok = {
+        component: "RefChecker",
+        _editable: `<!--#storyblok#{ "id": 12345, "uid": "fc34-uad1"}-->`,
+      };
+
+      const ref = cy.stub();
+
+      mount(
+        <Test
+          ref={ref}
+          accessToken="OurklwV5XsDJTIE1NJaD2wtt"
+          blok={blok}
+          components={{
+            RefChecker,
+          }}
+        />
+      ).then(() => {
+        expect(ref).to.be.calledOnce;
+      });
     });
   });
 

--- a/lib/testing-components/Test.tsx
+++ b/lib/testing-components/Test.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { forwardRef, useEffect } from "react";
 import {
   storyblokInit,
   apiPlugin,
@@ -16,31 +16,37 @@ interface TestProps {
   blok: SbBlokData | false;
 }
 
-const Test = ({ bridge, accessToken, components, blok }: TestProps) => {
-  storyblokInit({
-    accessToken,
-    bridge,
-    use: accessToken ? [apiPlugin] : [],
-    components,
-  });
+const Test = forwardRef<HTMLElement, TestProps>(
+  ({ bridge, accessToken, components, blok }, ref) => {
+    storyblokInit({
+      accessToken,
+      bridge,
+      use: accessToken ? [apiPlugin] : [],
+      components,
+    });
 
-  const storyblokApi = getStoryblokApi();
-  const apiExists = !!(storyblokApi && typeof storyblokApi.get === "function");
+    const storyblokApi = getStoryblokApi();
+    const apiExists = !!(
+      storyblokApi && typeof storyblokApi.get === "function"
+    );
 
-  useEffect(() => {
-    registerStoryblokBridge(43423, (newStory) => console.log(newStory));
-  }, []);
+    useEffect(() => {
+      registerStoryblokBridge(43423, (newStory) => console.log(newStory));
+    }, []);
 
-  return (
-    <div>
-      <h2>React Testing Component</h2>
-      <StoryblokComponent blok={blok} />
-      <h3>
-        <code>storyblokApi.get:</code>
-        <span data-test="api">{apiExists.toString()}</span>
-      </h3>
-    </div>
-  );
-};
+    return (
+      <div>
+        <h2>React Testing Component</h2>
+        <StoryblokComponent ref={ref} blok={blok} />
+        <h3>
+          <code>storyblokApi.get:</code>
+          <span data-test="api">{apiExists.toString()}</span>
+        </h3>
+      </div>
+    );
+  }
+);
+
+Test.displayName = "Test";
 
 export default Test;

--- a/playground/components/ref-checker.tsx
+++ b/playground/components/ref-checker.tsx
@@ -1,0 +1,25 @@
+import React, { forwardRef } from "react";
+import { storyblokEditable, SbBlokData } from "@storyblok/react";
+
+interface RefCheckerProps {
+  blok: SbBlokData;
+}
+
+const RefChecker = forwardRef<HTMLDivElement, RefCheckerProps>(
+  ({ blok }, ref) => {
+    return (
+      <div
+        {...storyblokEditable(blok)}
+        data-test="ref-checker"
+        key={blok._uid}
+        ref={ref}
+      >
+        Shoud have a passed ref
+      </div>
+    );
+  }
+);
+
+RefChecker.displayName = "RefChecker";
+
+export default RefChecker;


### PR DESCRIPTION
As already mentioned in the issue: it would be nice to have an ability to forward ref via StoryblokComponent. This PR should fix this issue. 

I created an extra component `RefChecker` for a testing sake. And also I added a new test case to check that the ref function is actually called.

It would be super cool if this PR will be merged sooner than later, cuz this is really handy and will improve the overall Storyblok React workflow a lot.

Thanks!

Closes #337 