### PR TITLE
Add ability to set components after initialized. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,6 +425,69 @@ export async function getStaticProps({ preview = false }) {
 
 **Check out the [code for the first part of our Next.js + Storyblok Ultimate Tutorial](https://github.com/storyblok/next.js-ultimate-tutorial/tree/part-1). Or you can also read on how to add Storyblok to a Next.js project in 5 minutes [here](https://www.storyblok.com/tp/add-a-headless-cms-to-next-js-in-5-minutes)**
 
+### 3. Adding components per page
+
+If you are using the pages router, you might want to load your components per page, instead of all in the `_app` file.
+
+If you load all components in the `_app` file with `storyblokInit` funciton, the JavaScript for all of those components will be loaded on every page, even on pages where most of these components might not be used.
+
+A better approach is to load these components on a per-page basis, reducing the JS bundle for that page, improving your load time, and SEO.
+
+Simply execute `storyblokInit` in the `_app` file as you did before, but omit the `components` object and the component imports like so:
+
+```diff
+import { storyblokInit, apiPlugin } from "@storyblok/react";
+
+/** Import your components */
+-import Page from "./components/Page";
+-import Teaser from "./components/Teaser";
+
+storyblokInit({
+  accessToken: "YOUR_ACCESS_TOKEN",
+  use: [apiPlugin],
+- components: {
+-   page: Page,
+-   teaser: Teaser,
+- },
+});
+```
+
+After that, use the `setComponent` method in each of your pages, to only load the components you need for that particular page:
+
+```diff
+import React from "react";
+import Teaser from "../components/teaser";
+import Grid from "../components/grid";
+import Page from "../components/page";
+import Feature from "../components/feature";
+
+import {
+  useStoryblokState,
+  StoryblokComponent,
++  setComponents,
+} from "@storyblok/react";
+
+export default function Home({
+  story: initialStory,
+}: InferGetStaticPropsType<typeof getStaticProps>) {
+
++  setComponents({
++    teaser: Teaser,
++    grid: Grid,
++    feature: Feature,
++    page: Page,
++  })
+  
+  const story = useStoryblokState(initialStory);
+
+  if (!story.content) {
+    return <div>Loading...</div>;
+  }
+
+  return <StoryblokComponent blok={story.content} />;
+}
+```
+
 ## Features and API
 
 You can **choose the features to use** when you initialize the plugin. In that way, you can improve Web Performance by optimizing your page load and save some bytes.

--- a/lib/common/index.ts
+++ b/lib/common/index.ts
@@ -7,7 +7,7 @@ import {
 } from "../types";
 
 let storyblokApiInstance: StoryblokClient = null;
-export let componentsMap: SbReactComponentsMap = {};
+let componentsMap: SbReactComponentsMap = {};
 
 export const useStoryblokApi = (): StoryblokClient => {
   if (!storyblokApiInstance) {

--- a/lib/common/index.ts
+++ b/lib/common/index.ts
@@ -7,7 +7,7 @@ import {
 } from "../types";
 
 let storyblokApiInstance: StoryblokClient = null;
-let componentsMap: SbReactComponentsMap = {};
+export let componentsMap: SbReactComponentsMap = {};
 
 export const useStoryblokApi = (): StoryblokClient => {
   if (!storyblokApiInstance) {
@@ -18,6 +18,11 @@ export const useStoryblokApi = (): StoryblokClient => {
 
   return storyblokApiInstance;
 };
+
+export const setComponents = (newComponentsMap: SbReactComponentsMap) => {
+  componentsMap = newComponentsMap;
+  return componentsMap;
+}
 
 export const getComponent = (componentKey: string) => {
   if (!componentsMap[componentKey]) {

--- a/playground-next/pages/_app.tsx
+++ b/playground-next/pages/_app.tsx
@@ -1,20 +1,11 @@
 import { AppProps } from "next/app";
 
 import { storyblokInit, apiPlugin } from "@storyblok/react";
-import Teaser from "../components/teaser";
-import Grid from "../components/grid";
-import Page from "../components/page";
-import Feature from "../components/feature";
+
 
 storyblokInit({
   accessToken: "d6IKUtAUDiKyAhpJtrLFcwtt",
   use: [apiPlugin],
-  components: {
-    teaser: Teaser,
-    grid: Grid,
-    feature: Feature,
-    page: Page,
-  },
 });
 
 function MyApp({ Component, pageProps }: AppProps) {

--- a/playground-next/pages/index.tsx
+++ b/playground-next/pages/index.tsx
@@ -1,15 +1,28 @@
 import React from "react";
 import { GetStaticProps, InferGetStaticPropsType } from "next";
+import Teaser from "../components/teaser";
+import Grid from "../components/grid";
+import Page from "../components/page";
+import Feature from "../components/feature";
 
 import {
   useStoryblokState,
   getStoryblokApi,
   StoryblokComponent,
+  setComponents,
 } from "@storyblok/react";
 
 export default function Home({
   story: initialStory,
 }: InferGetStaticPropsType<typeof getStaticProps>) {
+
+  setComponents({
+    teaser: Teaser,
+    grid: Grid,
+    feature: Feature,
+    page: Page,
+  })
+  
   const story = useStoryblokState(initialStory);
 
   if (!story.content) {


### PR DESCRIPTION
Currently it is not possible to set or access the components map, after `storyblokInit` has been executed.

This PR adds and exposes the `setComponents` method, so that components can be set at some point after initialization.
~~It also exposes the `componentsMap` variable, so it can be appended if needed~~


I've also taken the liberty of updating the next-demo to reflect the new usage, and the README.md where I thought it made sense. Please let me know if this is fine or if more work is needed here.

Related issue: https://github.com/storyblok/storyblok-react/issues/595