### PR TITLE
fix: add conditional story id for Gatsby use case in useStoryblokState

### DIFF
--- a/lib/common/client.ts
+++ b/lib/common/client.ts
@@ -4,7 +4,8 @@ import { registerStoryblokBridge } from "@storyblok/js";
 
 export const useStoryblokState: TUseStoryblokState = (
   initialStory = null,
-  bridgeOptions = {}
+  bridgeOptions = {},
+
 ) => {
   let [story, setStory] = useState(initialStory);
 
@@ -16,10 +17,12 @@ export const useStoryblokState: TUseStoryblokState = (
     return initialStory;
   }
 
+  const id = (story as any).internalId || story.id;
+
   useEffect(() => {
     setStory(initialStory);
     registerStoryblokBridge(
-      story.id,
+      id,
       (newStory) => setStory(newStory),
       bridgeOptions
     );

--- a/lib/story.tsx
+++ b/lib/story.tsx
@@ -12,7 +12,9 @@ interface StoryblokStoryProps {
 
 const StoryblokStory = forwardRef<HTMLElement, StoryblokStoryProps>(
   ({ story, ...restProps }, ref) => {
-    if (typeof story.content === "string") story.content = JSON.parse(story.content);
+    if (typeof story.content === "string") {
+      story.content = JSON.parse(story.content);
+    }
     story = useStoryblokState(story);
     return <StoryblokComponent ref={ref} blok={story.content} {...restProps} />;
   }

--- a/lib/story.tsx
+++ b/lib/story.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, {forwardRef} from "react";
+import React, { forwardRef } from "react";
 import { useStoryblokState } from "./common/client";
 import StoryblokComponent from "./common/storyblok-component";
 import { ISbStoryData } from "./types";
@@ -10,9 +10,10 @@ interface StoryblokStoryProps {
   [key: string]: unknown;
 }
 
-const StoryblokStory =  forwardRef<HTMLElement, StoryblokStoryProps>(
+const StoryblokStory = forwardRef<HTMLElement, StoryblokStoryProps>(
   ({ story, ...restProps }, ref) => {
-    story = useStoryblokState(story); 
+    if (typeof story.content === "string") story.content = JSON.parse(story.content);
+    story = useStoryblokState(story);
     return <StoryblokComponent ref={ref} blok={story.content} {...restProps} />;
   }
 );


### PR DESCRIPTION
### Background
In Gatsby, story id is named `internalId` as id is already reserved.
We could implement Gatsby standalone useStoryblokState, but this will cause us in the future to maintain two different useStoryblokState in React and Gatsby SDKs.

It'll lead to make us to think about why we designed and configured our JS SDK ecosystem.
(i.e. Maintain (some) common storyblok-js-client APIs → inherited into JS SDK → React SDK → Gatsby SDK)

### Implemented solution
- [x] Conditionally decides if the value is `id` or `internalId`
- [x] Conditionally checks if the type of `story.content` is string (Gatsby id is in string. Same as content.)

[https://github.com/storyblok/storyblok-react/compare/main...fix/conditional-story-id#](https://github.com/storyblok/storyblok-react/compare/main...fix/conditional-story-id#)