### PR TITLE
⬆️ Bump @storyblok/js to 3.1.9

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -58,7 +58,7 @@
     "react-dom": "^17.0.0 || ^18.0.0"
   },
   "dependencies": {
-    "@storyblok/js": "^3.1.1",
+    "@storyblok/js": "^3.1.9",
     "next": "14.2.14"
   },
   "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,8 +26,9 @@
     "lib": {
       "name": "@storyblok/react",
       "version": "0.0.1",
+      "license": "MIT",
       "dependencies": {
-        "@storyblok/js": "^3.1.1",
+        "@storyblok/js": "^3.1.9",
         "next": "14.2.14"
       },
       "devDependencies": {
@@ -2295,7 +2296,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -5097,12 +5098,12 @@
       }
     },
     "node_modules/@storyblok/js": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@storyblok/js/-/js-3.1.1.tgz",
-      "integrity": "sha512-aWdkFUWlzxCfUWXbnVCuqop8mdQ6RlmQcgi+vIbUlqdRODaSKR1j+Pv1RGugNX9OFo8Z2fbl5Ztnd9lF2nwpLg==",
+      "version": "3.1.9",
+      "resolved": "https://europe-npm.pkg.dev/durchblicker-at-registry/npm-proxy/@storyblok/js/-/js-3.1.9.tgz",
+      "integrity": "sha512-N8QB/yn8wQxM+G9kV/RHTsynuTyaMNwiAI2KFiwuT9QPo+Zea4EmikNJY1KxrA1Q8G8YiZEm7OBp1B3QDycA6g==",
       "dependencies": {
-        "@storyblok/richtext": "^2.0.0",
-        "storyblok-js-client": "^6.9.1"
+        "@storyblok/richtext": "^3.0.0",
+        "storyblok-js-client": "^6.10.3"
       }
     },
     "node_modules/@storyblok/react": {
@@ -5114,12 +5115,10 @@
       "link": true
     },
     "node_modules/@storyblok/richtext": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@storyblok/richtext/-/richtext-2.0.0.tgz",
-      "integrity": "sha512-yJm5BgWrCRGUdwZtviPgGno3rLXcnEvjK1bL1Ut4GmU1UOEVLC42m543EtrrOBVGDZdRPD9dK8ObgyHp6zNwqw==",
-      "dependencies": {
-        "consola": "^3.2.3"
-      }
+      "version": "3.0.2",
+      "resolved": "https://europe-npm.pkg.dev/durchblicker-at-registry/npm-proxy/@storyblok/richtext/-/richtext-3.0.2.tgz",
+      "integrity": "sha512-KBLx9ycNVMyVnNyPiwBH5g9uWmiJpMzp9YvpnnADXlPLoksusrwI56BusSM8HaIgJgcnB5RR0LvhySkPFdC8Zg==",
+      "license": "MIT"
     },
     "node_modules/@stylistic/eslint-plugin": {
       "version": "2.8.0",
@@ -7216,14 +7215,6 @@
       "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.7.tgz",
       "integrity": "sha512-uJcB/FKZtBMCJpK8MQji6bJHgu1tixKPxRLeGkNzBoOZzpnZUJm0jm2/sBDWcuBx1dYgxV4JU+g5hmNxCyAmdA==",
       "dev": true
-    },
-    "node_modules/consola": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/consola/-/consola-3.2.3.tgz",
-      "integrity": "sha512-I5qxpzLv+sJhTVEoLYNcTW+bThDCPsit0vLNKShZx6rLtpilNpmmeTPaeqJb9ZE9dV3DGaeby6Vuhrw38WjeyQ==",
-      "engines": {
-        "node": "^14.18.0 || >=16.10.0"
-      }
     },
     "node_modules/conventional-changelog-angular": {
       "version": "7.0.0",
@@ -14809,9 +14800,10 @@
       }
     },
     "node_modules/storyblok-js-client": {
-      "version": "6.9.1",
-      "resolved": "https://registry.npmjs.org/storyblok-js-client/-/storyblok-js-client-6.9.1.tgz",
-      "integrity": "sha512-mXCSNIr7tvFzH+TibM7hbq+xNAeDWnrfQwh8HS4fLskVHwQ2HaCQG9BkdbT1zWUFav3HWB+B8kqi3+KjRG1CUg=="
+      "version": "6.10.3",
+      "resolved": "https://europe-npm.pkg.dev/durchblicker-at-registry/npm-proxy/storyblok-js-client/-/storyblok-js-client-6.10.3.tgz",
+      "integrity": "sha512-q6YK/f+F8PAJLsKR7jzlTRO9yIUXWLON2Fy02QjywYaSYwyS9ETzIuOtmCSstLrDAP5I+Vnw9PzEU30roxS15g==",
+      "license": "MIT"
     },
     "node_modules/stream-combiner": {
       "version": "0.0.4",
@@ -18283,7 +18275,7 @@
         "is-unicode-supported": {
           "version": "1.3.0",
           "bundled": true,
-          "extraneous": true
+          "dev": true
         }
       }
     },
@@ -20067,12 +20059,12 @@
       }
     },
     "@storyblok/js": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@storyblok/js/-/js-3.1.1.tgz",
-      "integrity": "sha512-aWdkFUWlzxCfUWXbnVCuqop8mdQ6RlmQcgi+vIbUlqdRODaSKR1j+Pv1RGugNX9OFo8Z2fbl5Ztnd9lF2nwpLg==",
+      "version": "3.1.9",
+      "resolved": "https://europe-npm.pkg.dev/durchblicker-at-registry/npm-proxy/@storyblok/js/-/js-3.1.9.tgz",
+      "integrity": "sha512-N8QB/yn8wQxM+G9kV/RHTsynuTyaMNwiAI2KFiwuT9QPo+Zea4EmikNJY1KxrA1Q8G8YiZEm7OBp1B3QDycA6g==",
       "requires": {
-        "@storyblok/richtext": "^2.0.0",
-        "storyblok-js-client": "^6.9.1"
+        "@storyblok/richtext": "^3.0.0",
+        "storyblok-js-client": "^6.10.3"
       }
     },
     "@storyblok/react": {
@@ -20082,7 +20074,7 @@
         "@babel/preset-env": "^7.25.4",
         "@cypress/react": "^8.0.2",
         "@cypress/vite-dev-server": "^5.2.0",
-        "@storyblok/js": "^3.1.1",
+        "@storyblok/js": "^3.1.9",
         "@tsconfig/recommended": "^1.0.7",
         "@types/react": "18.3.4",
         "@vitejs/plugin-react": "^4.3.1",
@@ -20253,12 +20245,9 @@
       }
     },
     "@storyblok/richtext": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@storyblok/richtext/-/richtext-2.0.0.tgz",
-      "integrity": "sha512-yJm5BgWrCRGUdwZtviPgGno3rLXcnEvjK1bL1Ut4GmU1UOEVLC42m543EtrrOBVGDZdRPD9dK8ObgyHp6zNwqw==",
-      "requires": {
-        "consola": "^3.2.3"
-      }
+      "version": "3.0.2",
+      "resolved": "https://europe-npm.pkg.dev/durchblicker-at-registry/npm-proxy/@storyblok/richtext/-/richtext-3.0.2.tgz",
+      "integrity": "sha512-KBLx9ycNVMyVnNyPiwBH5g9uWmiJpMzp9YvpnnADXlPLoksusrwI56BusSM8HaIgJgcnB5RR0LvhySkPFdC8Zg=="
     },
     "@stylistic/eslint-plugin": {
       "version": "2.8.0",
@@ -21698,11 +21687,6 @@
       "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.7.tgz",
       "integrity": "sha512-uJcB/FKZtBMCJpK8MQji6bJHgu1tixKPxRLeGkNzBoOZzpnZUJm0jm2/sBDWcuBx1dYgxV4JU+g5hmNxCyAmdA==",
       "dev": true
-    },
-    "consola": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/consola/-/consola-3.2.3.tgz",
-      "integrity": "sha512-I5qxpzLv+sJhTVEoLYNcTW+bThDCPsit0vLNKShZx6rLtpilNpmmeTPaeqJb9ZE9dV3DGaeby6Vuhrw38WjeyQ=="
     },
     "conventional-changelog-angular": {
       "version": "7.0.0",
@@ -27216,9 +27200,9 @@
       }
     },
     "storyblok-js-client": {
-      "version": "6.9.1",
-      "resolved": "https://registry.npmjs.org/storyblok-js-client/-/storyblok-js-client-6.9.1.tgz",
-      "integrity": "sha512-mXCSNIr7tvFzH+TibM7hbq+xNAeDWnrfQwh8HS4fLskVHwQ2HaCQG9BkdbT1zWUFav3HWB+B8kqi3+KjRG1CUg=="
+      "version": "6.10.3",
+      "resolved": "https://europe-npm.pkg.dev/durchblicker-at-registry/npm-proxy/storyblok-js-client/-/storyblok-js-client-6.10.3.tgz",
+      "integrity": "sha512-q6YK/f+F8PAJLsKR7jzlTRO9yIUXWLON2Fy02QjywYaSYwyS9ETzIuOtmCSstLrDAP5I+Vnw9PzEU30roxS15g=="
     },
     "stream-combiner": {
       "version": "0.0.4",


### PR DESCRIPTION
Since lately there have been many caching related fixes/improvements to the js-client, I bumped the upstream package so React SDK users can benefit from the updates.

Also closes #1249 