### PR TITLE
chore: increment commit body max size to allow dependabot commits

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,10 @@
   "commitlint": {
     "extends": [
       "@commitlint/config-conventional"
-    ]
+    ],
+    "rules": {
+      "body-max-line-length": [2, "always", 200]
+    }
   },
   "release": {
     "branches": [


### PR DESCRIPTION
Increment the body line max lenght of the commit - default was 100