### PR TITLE
fix(rsc): prevent draft content leaks in visual editor

### DIFF
--- a/src/__tests__/live-editing.test.ts
+++ b/src/__tests__/live-editing.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest';
+import StoryblokLiveEditing from '../rsc/live-editing';
+import type { ISbStoryData } from '@storyblok/js';
+
+describe('storyblokLiveEditing', () => {
+  it('should return null when not in visual editor', () => {
+    const component = StoryblokLiveEditing({ story: { uuid: '123' } as ISbStoryData, bridgeOptions: {} });
+    expect(component).toBeNull();
+  });
+});

--- a/src/rsc/common.ts
+++ b/src/rsc/common.ts
@@ -11,7 +11,12 @@ const componentsMap: Map<string, React.ElementType> = new Map<string, React.Elem
 let enableFallbackComponent: boolean = false;
 let customFallbackComponent: React.ElementType = null;
 
-globalThis.storyCache = new Map<string, ISbStoryData>();
+declare global {
+  // eslint-disable-next-line no-var, vars-on-top
+  var storyCache: Map<string, ISbStoryData>;
+}
+
+globalThis.storyCache = !globalThis.storyCache ? new Map<string, ISbStoryData>() : globalThis.storyCache;
 
 export const useStoryblokApi = (): StoryblokClient => {
   if (!storyblokApiInstance) {

--- a/src/rsc/live-edit-update-action.ts
+++ b/src/rsc/live-edit-update-action.ts
@@ -1,6 +1,8 @@
 'use server';
 
-export async function liveEditUpdateAction({ story, pathToRevalidate }) {
+import type { ISbStoryData } from '@storyblok/js';
+
+export async function liveEditUpdateAction({ story, pathToRevalidate }: { story: ISbStoryData; pathToRevalidate: string }) {
   if (!story || !pathToRevalidate) {
     return console.error('liveEditUpdateAction: story or pathToRevalidate is not provided');
   }

--- a/src/rsc/live-editing.tsx
+++ b/src/rsc/live-editing.tsx
@@ -1,15 +1,22 @@
 'use client';
 
-import { registerStoryblokBridge } from '@storyblok/js';
+import { type ISbStoryData, registerStoryblokBridge, type StoryblokBridgeConfigV2 } from '@storyblok/js';
 import { startTransition, useEffect } from 'react';
 import { liveEditUpdateAction } from './live-edit-update-action';
 
-const StoryblokLiveEditing = ({ story = null, bridgeOptions = {} }) => {
+const isVisualEditor = (): boolean => {
   if (typeof window === 'undefined') {
+    return false;
+  }
+  return typeof window.storyblokRegisterEvent !== 'undefined' && window.location.search.includes('_storyblok');
+};
+
+const StoryblokLiveEditing = ({ story = null, bridgeOptions = {} }: { story: ISbStoryData; bridgeOptions: StoryblokBridgeConfigV2 }) => {
+  if (!isVisualEditor()) {
     return null;
   }
 
-  const handleInput = (story) => {
+  const handleInput = (story: ISbStoryData) => {
     if (!story) {
       return;
     }

--- a/src/rsc/story.tsx
+++ b/src/rsc/story.tsx
@@ -19,6 +19,8 @@ const StoryblokStory = forwardRef<HTMLElement, StoryblokStoryProps>(
 
     if (globalThis.storyCache.has(story.uuid)) {
       story = globalThis.storyCache.get(story.uuid);
+      // Delete the story from the cache to avoid draft content leaking
+      globalThis.storyCache.delete(story.uuid);
     }
 
     if (typeof story.content === 'string') {


### PR DESCRIPTION
**Description:**

This PR fixes a potential security issue where draft content could leak between requests in the visual editor. It also improves type safety and optimizes visual editor detection.

Key changes:
- Cache cleanup after story retrieval to prevent content leaks
- Optimized Visual Editor detection logic

**Testing:**
Changes have been tested in local environment with visual editor. Additional integration tests are planned.