### PR TITLE
feat(deps): bump @storyblok/js from 3.2.5 to 3.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "react-dom": "^17 || ^18 || ^19"
   },
   "dependencies": {
-    "@storyblok/js": "3.2.5"
+    "@storyblok/js": "3.3.0"
   },
   "devDependencies": {
     "@babel/core": "^7.26.7",
@@ -88,7 +88,9 @@
     "vitest": "^3.0.5"
   },
   "pnpm": {
-    "onlyBuiltDependencies": ["cypress"]
+    "onlyBuiltDependencies": [
+      "cypress"
+    ]
   },
   "babel": {
     "presets": [
@@ -107,7 +109,11 @@
       "@commitlint/config-conventional"
     ],
     "rules": {
-      "body-max-line-length": [2, "always", 200]
+      "body-max-line-length": [
+        2,
+        "always",
+        200
+      ]
     }
   },
   "release": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@storyblok/js':
-        specifier: 3.2.5
-        version: 3.2.5
+        specifier: 3.3.0
+        version: 3.3.0
       next:
         specifier: ^13 || ^14 || ^15
         version: 13.5.7(@babel/core@7.26.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1891,6 +1891,9 @@ packages:
   '@storyblok/js@3.2.5':
     resolution: {integrity: sha512-G9AO5qamMpLyBgCGaPywqPRzwLcPKkQY1sugRSAMq9ckgyKOwUyV7iXKA5WcYyM79MeorcmNtaT3kapYMgD4FQ==}
 
+  '@storyblok/js@3.3.0':
+    resolution: {integrity: sha512-+i0I6nvbCXnfO6L5b5SYvoqLHUb1j3iIznuN/tcGO9c8MYNopY7XGOjrOOTlJVAoiFECJyzYiwC7mDRwrotvfw==}
+
   '@storyblok/react@file:':
     resolution: {directory: '', type: directory}
     peerDependencies:
@@ -1900,6 +1903,9 @@ packages:
 
   '@storyblok/richtext@3.0.2':
     resolution: {integrity: sha512-KBLx9ycNVMyVnNyPiwBH5g9uWmiJpMzp9YvpnnADXlPLoksusrwI56BusSM8HaIgJgcnB5RR0LvhySkPFdC8Zg==}
+
+  '@storyblok/richtext@3.1.0':
+    resolution: {integrity: sha512-QtH5G+F7w3YuGGnHAFldo71vPpBT5prndZWFPDihlIsWaW0rEWyE9iX+6fp2f4XDgbhi0vyF1HqajFplGOtFVg==}
 
   '@stylistic/eslint-plugin@2.10.1':
     resolution: {integrity: sha512-U+4yzNXElTf9q0kEfnloI9XbOyD4cnEQCxjUI94q0+W++0GAEQvJ/slwEj9lwjDHfGADRSr+Tco/z0XJvmDfCQ==}
@@ -7544,6 +7550,11 @@ snapshots:
       '@storyblok/richtext': 3.0.2
       storyblok-js-client: 6.10.10
 
+  '@storyblok/js@3.3.0':
+    dependencies:
+      '@storyblok/richtext': 3.1.0
+      storyblok-js-client: 6.10.10
+
   '@storyblok/react@file:(next@13.5.7(@babel/core@7.26.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@storyblok/js': 3.2.5
@@ -7552,6 +7563,8 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
 
   '@storyblok/richtext@3.0.2': {}
+
+  '@storyblok/richtext@3.1.0': {}
 
   '@stylistic/eslint-plugin@2.10.1(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3)':
     dependencies:


### PR DESCRIPTION
- Updated @storyblok/js from 3.2.3 to 3.3.0
- Updated storyblok-js-client from 6.10.8 to 6.10.10
- Updated @storyblok/richtext from 3.0.2 to 3.1.0

This change enables table support for richtext resolvers