### PR TITLE
fix: rename useStoryblokRichTextResolver to useStoryblokRichText

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,8 @@ import type {
 
 import { getStoryblokApi } from './common';
 
+import { useStoryblokRichText } from './richtext';
+
 export const useStoryblok = (
   slug: string,
   apiOptions: ISbStoriesParams = {},
@@ -64,6 +66,12 @@ export const useStoryblok = (
 
 export * from './common/client';
 export * from './common/index';
-export { useStoryblokRichTextResolver } from './richtext';
+
+// Export the main function
+export { useStoryblokRichText };
+
+/** @deprecated Use useStoryblokRichText instead */
+export const useStoryblokRichTextResolver = useStoryblokRichText;
+
 export { default as StoryblokRichText } from './storyblok-rich-text';
 export * from './utils';

--- a/src/richtext.ts
+++ b/src/richtext.ts
@@ -11,7 +11,7 @@ export function componentResolver(node: StoryblokRichTextNode<React.ReactElement
   });
 }
 
-export function useStoryblokRichTextResolver(
+export function useStoryblokRichText(
   options: StoryblokRichTextOptions<React.ReactElement>,
 ) {
   const mergedOptions = {

--- a/src/rsc/index.ts
+++ b/src/rsc/index.ts
@@ -1,4 +1,11 @@
-export { useStoryblokRichTextResolver } from '../richtext';
+import { useStoryblokRichText } from '../richtext';
+
+// Export the main function
+export { useStoryblokRichText };
+
+/** @deprecated Use useStoryblokRichText instead */
+export const useStoryblokRichTextResolver = useStoryblokRichText;
+
 export { default as StoryblokRichText } from '../storyblok-rich-text';
 export * from './common';
 export { default as StoryblokStory } from './story';

--- a/src/storyblok-rich-text.tsx
+++ b/src/storyblok-rich-text.tsx
@@ -1,12 +1,12 @@
 import React, { forwardRef } from 'react';
 
 import { convertAttributesInElement } from './utils';
-import { useStoryblokRichTextResolver } from './richtext';
+import { useStoryblokRichText } from './richtext';
 import type { StoryblokRichTextProps } from './types';
 
 const StoryblokRichText = forwardRef<HTMLDivElement, StoryblokRichTextProps>(
   ({ doc, resolvers }, ref) => {
-    const { render } = useStoryblokRichTextResolver({
+    const { render } = useStoryblokRichText({
       resolvers,
     });
 


### PR DESCRIPTION
This commit refactors the rich text resolver by renaming `useStoryblokRichTextResolver` to `useStoryblokRichText` for clarity and consistency. The deprecated function `useStoryblokRichTextResolver` now points to the new function, ensuring backward compatibility.

Closes #1356 